### PR TITLE
make get_binary_cols work with columns that have parentheses in name

### DIFF
--- a/R/select_multiple_cleaning.R
+++ b/R/select_multiple_cleaning.R
@@ -65,6 +65,7 @@ sm_val_remover <- function(q_name, value, filter_expr, var_uuid, var_index, rele
 #'
 #' @noRd
 get_binary_cols <- function(q_name, sheet, choices, env) {
+  choices <- choices %>% str_replace_all(c("\\("="\\\\(","\\)"="\\\\)")) #escape parentheses
   search_rgx <- glue("(\\b{q_name})(\\.|\\/)({choices}\\b)")
   search_rgx <- glue_collapse(search_rgx, sep = "|")
   unique(names(env$object[[sheet]] %>%


### PR DESCRIPTION
just added some escape characters to the get_binary_cols function so that the regex matching works on columns that have parentheses in there names.